### PR TITLE
 Problem: too much low-level module lookup in high-level code 

### DIFF
--- a/mods/rkt/cardano-wallet/main.rkt
+++ b/mods/rkt/cardano-wallet/main.rkt
@@ -6,15 +6,12 @@
 (require fractalide/modules/rkt/rkt-fbp/scheduler)
 (require (prefix-in graph: fractalide/modules/rkt/rkt-fbp/graph))
 
-; Required to make the resolved-module-path below valid
-(require fractalide/modules/rkt/rkt-fbp/agents/test/main)
-
 (module+ main
   (define sched (make-scheduler #f))
   (setup-fvm sched)
   (sched (msg-mesg "sched" "acc" (make-scheduler #f)))
   (sched (msg-mesg "halt" "in" #f))
-  (define path (make-resolved-module-path (fbp-agents-lookup "test/main.rkt")))
+  (define path (fbp-agents-string->symbol "test/main"))
   (define a-graph (graph:make-graph (graph:node "main" path)))
   (sched (msg-mesg "fvm" "in" (cons 'add a-graph)))
   (sched (msg-mesg "fvm" "in" (cons 'stop #t)))

--- a/mods/rkt/fvm/setup.rkt
+++ b/mods/rkt/fvm/setup.rkt
@@ -5,21 +5,21 @@
          fractalide/modules/rkt/rkt-fbp/agent
          (prefix-in graph: fractalide/modules/rkt/rkt-fbp/graph))
 
-(provide setup-fvm fbp-agents-lookup)
+(provide setup-fvm fbp-agents-string->symbol)
 
-(define (fbp-agents-lookup agent-relative-path)
-  (collection-file-path agent-relative-path
-                        "fractalide" "modules" "rkt" "rkt-fbp" "agents"))
+(define (fbp-agents-string->symbol agent-relative-path)
+  (string->symbol (string-append "fractalide/modules/rkt/rkt-fbp/agents/"
+                                 agent-relative-path)))
 
 (define (setup-fvm sched)
-  (for ([name+agent '(("sched" "fvm/scheduler.rkt")
-                      ("load-graph" "fvm/load-graph.rkt")
-                      ("get-graph" "fvm/get-graph.rkt")
-                      ("get-path" "fvm/get-path.rkt")
-                      ("fvm" "fvm/fvm.rkt")
-                      ("halt" "halter.rkt"))])
+  (for ([name+agent '(("sched" "fvm/scheduler")
+                      ("load-graph" "fvm/load-graph")
+                      ("get-graph" "fvm/get-graph")
+                      ("get-path" "fvm/get-path")
+                      ("fvm" "fvm/fvm")
+                      ("halt" "halter"))])
     (match-define (list name agent) name+agent)
-    (sched (msg-add-agent name (fbp-agents-lookup agent))))
+    (sched (msg-add-agent name (fbp-agents-string->symbol agent))))
   (sched (msg-connect "fvm" "sched" "sched" "in"))
   (sched (msg-connect "fvm" "flat" "load-graph" "in"))
   (sched (msg-connect "fvm" "halt" "halt" "in"))


### PR DESCRIPTION
Solution: Turn module paths into symbols and let racket do the lifting.

This delegates all the collection file path stuff to dynamic-require.