### PR TITLE
Problem: rename from 'cardano-wallet' to 'cantor' failing on hydra

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 let
 attrs = {
-  cardano-wallet = import modules/rkt args;
+  cantor = import modules/rkt args;
 };
 in
-attrs // attrs.cardano-wallet
+attrs // attrs.cantor

--- a/release.nix
+++ b/release.nix
@@ -3,8 +3,8 @@
 }:
 
 {
-  cardano-wallet = import <cardano-wallet> {};
-  cardano-wallet-nixpkgs-unstable = pkgs.callPackage <cardano-wallet> {};
+  cantor = import <cantor> {};
+  cantor-nixpkgs-unstable = pkgs.callPackage <cantor> {};
 } // pkgs.lib.optionalAttrs isTravis {
-  travisOrder = [ "cardano-wallet" ];
+  travisOrder = [ "cantor" ];
 }


### PR DESCRIPTION
Solution: rename the nix attributes in default.nix + release.nix